### PR TITLE
fixed encoding as noticed by xianda

### DIFF
--- a/apps/specest_from_file.py
+++ b/apps/specest_from_file.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# coding=utf-8
+# vim: set fileencoding=utf-8 :
 #
 # Copyright 2009,2010,2013 Communications Engineering Lab, KIT
 #


### PR DESCRIPTION
# coding=utf8

is not a valid way to tell python how the file is encoded. corrected this :)
