### PR TITLE
Bug-Fix for non-handed window vector (see discuss@gnuradio)

### DIFF
--- a/lib/welch_impl.cc
+++ b/lib/welch_impl.cc
@@ -28,51 +28,51 @@
 namespace gr {
   namespace specest {
 
-	/**
-	 * \brief Calculate the correct normalisation factor
-	 *
-	 * The following is considered:
-	 * - FFT length (so Parseval's theorem can be applied)
-	 * - The length of the moving average (because the scaling is done after the summation)
-	 * - The power of the window function
-	 */
-	inline float
-	specest_calculate_ma_scale_impl(int fft_len, int ma_len, const std::vector<float> &window)
-	{
+    /**
+    * \brief Calculate the correct normalisation factor
+    *
+    * The following is considered:
+    * - FFT length (so Parseval's theorem can be applied)
+    * - The length of the moving average (because the scaling is done after the summation)
+    * - The power of the window function
+    */
+    inline float
+    specest_calculate_ma_scale_impl(int fft_len, int ma_len, const std::vector<float> &window)
+    {
 
-		float scale = 1.0 / (fft_len * ma_len * 2 * M_PI);
-		if (window.size() == 0) {
-			return scale;
-		}
+      float scale = 1.0 / (fft_len * ma_len * 2 * M_PI);
+      if (window.size() == 0) {
+        return scale;
+      }
 
-		float window_power = 0;
-		for(unsigned i = 0; i < window.size(); i++) {
-			window_power += window[i] * window[i];
-		}
-		window_power /= fft_len;
+      float window_power = 0;
+      for(unsigned i = 0; i < window.size(); i++) {
+        window_power += window[i] * window[i];
+      }
+      window_power /= fft_len;
 
-		return scale / window_power;
-	}
+      return scale / window_power;
+    }
 
-	// I'd prefer doing this in the specest constructor, but for some reason throwing
-	// exceptions in the constructor ends up in seg faults in the Python domain
-	inline void
-	specest_check_arguments_impl(unsigned fft_len, int overlap, const std::vector<float> &window)
-	{
-		if (window.size() != 0 && window.size() != fft_len) {
-			throw std::invalid_argument("specest_welch: when providing a window, it must have the same length as fft_len.");
-		}
-		if (overlap < -1) {
-			throw std::invalid_argument("specest_welch: overlap can not be negative.");
-		}
-	}
+    // I'd prefer doing this in the specest constructor, but for some reason throwing
+    // exceptions in the constructor ends up in seg faults in the Python domain
+    inline void
+    specest_check_arguments_impl(unsigned fft_len, int overlap, const std::vector<float> &window)
+    {
+      if (window.size() != 0 && window.size() != fft_len) {
+        throw std::invalid_argument("specest_welch: when providing a window, it must have the same length as fft_len.");
+      }
+      if (overlap < -1) {
+        throw std::invalid_argument("specest_welch: overlap can not be negative.");
+      }
+    }
 
     welch::sptr
     welch::make(unsigned fft_len, int overlap, int ma_len, bool fft_shift, const std::vector<float> &window)
     {
       specest_check_arguments_impl(fft_len, overlap, window);
       return gnuradio::get_initial_sptr
-        (new welch_impl(fft_len, overlap, ma_len, fft_shift, window));
+              (new welch_impl(fft_len, overlap, ma_len, fft_shift, window));
     }
 
     welch::sptr
@@ -80,23 +80,23 @@ namespace gr {
     {
       std::vector<float> window;
       if (window_type != filter::firdes::WIN_RECTANGULAR) {
-	std::vector<float> window = filter::firdes::window((filter::firdes::win_type)window_type, fft_len, beta);
+        window = filter::firdes::window((filter::firdes::win_type)window_type, fft_len, beta);
       }
       specest_check_arguments_impl(fft_len, overlap, window);
       return gnuradio::get_initial_sptr
-	(new welch_impl(fft_len, overlap, ma_len, fft_shift, window));
+              (new welch_impl(fft_len, overlap, ma_len, fft_shift, window));
     }
 
     welch_impl::welch_impl(unsigned fft_len, int overlap, int ma_len, bool fft_shift, const std::vector<float> &window)
       : gr::hier_block2("welch",
-	    gr::io_signature::make(1, 1, sizeof(gr_complex)),
-	    gr::io_signature::make(1, 1, sizeof(float) * fft_len)),
-		d_fft_len(fft_len),
-		d_stream_to_vector(stream_to_vector_overlap::make(sizeof(gr_complex), fft_len, (overlap == -1) ? fft_len/2 : overlap)),
-		d_fft(fft::fft_vcc::make(fft_len, true, window, fft_shift)),
-		d_mag_square(blocks::complex_to_mag_squared::make(fft_len)),
-		d_moving_average(moving_average_vff::make(ma_len, fft_len,
-		specest_calculate_ma_scale_impl(fft_len, ma_len, window)))
+          gr::io_signature::make(1, 1, sizeof(gr_complex)),
+          gr::io_signature::make(1, 1, sizeof(float) * fft_len)),
+      d_fft_len(fft_len),
+      d_stream_to_vector(stream_to_vector_overlap::make(sizeof(gr_complex), fft_len, (overlap == -1) ? fft_len/2 : overlap)),
+      d_fft(fft::fft_vcc::make(fft_len, true, window, fft_shift)),
+      d_mag_square(blocks::complex_to_mag_squared::make(fft_len)),
+      d_moving_average(moving_average_vff::make(ma_len, fft_len,
+      specest_calculate_ma_scale_impl(fft_len, ma_len, window)))
     {
       connect(self(), 0, d_stream_to_vector, 0);
       connect(d_stream_to_vector, 0, d_fft, 0);

--- a/lib/welchsp_impl.cc
+++ b/lib/welchsp_impl.cc
@@ -36,12 +36,12 @@ namespace gr {
     {
       float scale = 1.0 / (fft_len * 2 * M_PI);
       if (window.size() == 0) {
-	return scale;
+        return scale;
       }
 
       float window_power = 0;
       for(unsigned i = 0; i < window.size(); i++) {
-	window_power += window[i] * window[i];
+        window_power += window[i] * window[i];
       }
       window_power /= fft_len;
 
@@ -54,10 +54,10 @@ namespace gr {
     specest_check_arguments_impl(unsigned fft_len, int overlap, const std::vector<float> &window)
     {
       if (window.size() != 0 && window.size() != fft_len) {
-	throw std::invalid_argument("specest_welchsp: when providing a window, it must have the same length as fft_len.");
+        throw std::invalid_argument("specest_welchsp: when providing a window, it must have the same length as fft_len.");
       }
       if (overlap < -1) {
-	throw std::invalid_argument("specest_welchsp: overlap can not be negative.");
+        throw std::invalid_argument("specest_welchsp: overlap can not be negative.");
       }
     }
 
@@ -66,7 +66,7 @@ namespace gr {
     {
       specest_check_arguments_impl(fft_len, overlap, window);
       return gnuradio::get_initial_sptr
-	(new welchsp_impl(fft_len, overlap, alpha, fft_shift, window));
+              (new welchsp_impl(fft_len, overlap, alpha, fft_shift, window));
     }
 
     welchsp::sptr
@@ -74,17 +74,17 @@ namespace gr {
     {
       std::vector<float> window;
       if (window_type != gr::filter::firdes::WIN_RECTANGULAR) {
-	std::vector<float> window = gr::filter::firdes::window((gr::filter::firdes::win_type)window_type, fft_len, beta);
+        std::vector<float> window = gr::filter::firdes::window((gr::filter::firdes::win_type)window_type, fft_len, beta);
       }
       specest_check_arguments_impl(fft_len, overlap, window);
       return gnuradio::get_initial_sptr
-	(new welchsp_impl(fft_len, overlap, alpha, fft_shift, window));
+              (new welchsp_impl(fft_len, overlap, alpha, fft_shift, window));
     }
 
     welchsp_impl::welchsp_impl(unsigned fft_len, int overlap, double alpha, bool fft_shift, const std::vector<float> &window)
       : gr::hier_block2("welchsp",
-	  gr::io_signature::make(1, 1, sizeof(gr_complex)),
-	  gr::io_signature::make(1, 1, sizeof(float) * fft_len)),
+          gr::io_signature::make(1, 1, sizeof(gr_complex)),
+          gr::io_signature::make(1, 1, sizeof(float) * fft_len)),
       d_fft_len(fft_len),
       d_stream_to_vector(gr::specest::stream_to_vector_overlap::make(sizeof(gr_complex), fft_len, (overlap == -1) ? fft_len/2 : overlap)),
       d_fft(gr::fft::fft_vcc::make(fft_len, true, window, fft_shift)),


### PR DESCRIPTION
In welch_impl.cc and welchps_impl.cc there is a bug in a constructor using the windowing function. The window vector is not handed down to the constructor, because the variable written to shadowes the variable that is passed as window vector to the underlying constructor. This Pull request fixes this bug.

/donludovico